### PR TITLE
Add prometheus metrics endpoint

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -15,6 +15,10 @@ destination = "/data"
 [deploy]
 release_command = "node ./other/sentry-create-release"
 
+[metrics]
+port = 9091
+path = "/metrics"
+
 [[services]]
 internal_port = 8080
 processes = [ "app" ]

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
         "luxon": "^3.4.3",
         "morgan": "^1.10.0",
         "prisma": "^5.1.1",
+        "prom-client": "^15.0.0",
         "qrcode": "^1.5.3",
         "ra-data-json-server": "^4.13.3",
         "ra-data-simple-prisma": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ dependencies:
     prisma:
         specifier: ^5.1.1
         version: 5.1.1
+    prom-client:
+        specifier: ^15.0.0
+        version: 15.0.0
     qrcode:
         specifier: ^1.5.3
         version: 1.5.3
@@ -4076,6 +4079,14 @@ packages:
             }
         dev: true
 
+    /@opentelemetry/api@1.6.0:
+        resolution:
+            {
+                integrity: sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==,
+            }
+        engines: { node: '>=8.0.0' }
+        dev: false
+
     /@paralleldrive/cuid2@2.2.2:
         resolution:
             {
@@ -7786,6 +7797,13 @@ packages:
             }
         dependencies:
             file-uri-to-path: 1.0.0
+
+    /bintrees@1.0.2:
+        resolution:
+            {
+                integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==,
+            }
+        dev: false
 
     /bl@4.1.0:
         resolution:
@@ -15434,6 +15452,17 @@ packages:
         engines: { node: '>=0.4.0' }
         dev: false
 
+    /prom-client@15.0.0:
+        resolution:
+            {
+                integrity: sha512-UocpgIrKyA2TKLVZDSfm8rGkL13C19YrQBAiG3xo3aDFWcHedxRxI3z+cIcucoxpSO0h5lff5iv/SXoxyeopeA==,
+            }
+        engines: { node: ^16 || ^18 || >=20 }
+        dependencies:
+            '@opentelemetry/api': 1.6.0
+            tdigest: 0.1.2
+        dev: false
+
     /promise-inflight@1.0.1:
         resolution:
             {
@@ -18000,6 +18029,15 @@ packages:
             mkdirp: 1.0.4
             yallist: 4.0.0
         dev: true
+
+    /tdigest@0.1.2:
+        resolution:
+            {
+                integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==,
+            }
+        dependencies:
+            bintrees: 1.0.2
+        dev: false
 
     /test-exclude@6.0.0:
         resolution:

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,6 @@
+import crypto from 'crypto';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import {
     createRequestHandler as _createRequestHandler,
     type RequestHandler,
@@ -13,18 +16,21 @@ import chalk from 'chalk';
 import chokidar from 'chokidar';
 import closeWithGrace from 'close-with-grace';
 import compression from 'compression';
-import crypto from 'crypto';
 import express from 'express';
 import rateLimit from 'express-rate-limit';
 import getPort, { portNumbers } from 'get-port';
 import helmet from 'helmet';
 import morgan from 'morgan';
-import path from 'path';
-import { fileURLToPath } from 'url';
 
 // @ts-ignore - this file may not exist if you haven't built yet, but it will
 // definitely exist by the time the dev or prod server actually runs.
 import * as remixBuild from '#build/index.js';
+import { type prometheus as prometheusType } from '#server/prometheus.server.ts';
+// @ts-ignore - this file may not exist if you haven't built yet, but it will
+// definitely exist by the time the dev or prod server actually runs.
+import { prometheus as _prometheus } from '#server-build/prometheus.server.js';
+
+const prometheus = _prometheus as typeof prometheusType;
 
 installGlobals();
 
@@ -88,6 +94,22 @@ app.use(
 // Everything else (like favicon.ico) is cached for an hour. You may want to be
 // more aggressive with this caching.
 app.use(express.static('public', { maxAge: '1h' }));
+
+app.use((req, res, next) => {
+    const start = Date.now();
+    res.on('finish', () => {
+        const duration = Date.now() - start;
+        prometheus.requestCounter.inc({
+            method: req.method,
+            path: req.path,
+            status: res.statusCode.toString(),
+        });
+        prometheus.requestDuration.observe({ path: req.path }, duration);
+        prometheus.requestDurationSummary.observe({ path: req.path }, duration);
+    });
+
+    next();
+});
 
 morgan.token('url', (req, res) => decodeURIComponent(req.url ?? ''));
 app.use(morgan('tiny'));
@@ -196,6 +218,31 @@ app.all(
         : getRequestHandler(build),
 );
 
+const metricsApp = express();
+
+metricsApp.use(morgan('tiny'));
+
+metricsApp.get('/metrics', async (_, res) => {
+    const metrics = await prometheus.client.register.metrics();
+    res.set('Content-Type', 'text/plain');
+    res.send(metrics);
+});
+
+const desiredMetricsPort = 9091;
+const metricsPort = await getPort({
+    port: portNumbers(desiredMetricsPort, desiredMetricsPort + 100),
+});
+const metricsServer = metricsApp.listen(metricsPort, () => {
+    if (metricsPort !== desiredMetricsPort) {
+        console.warn(
+            chalk.yellow(
+                `⚠️  Metrics port ${desiredMetricsPort} is not available, using ${metricsPort} instead.`,
+            ),
+        );
+    }
+    console.log(`📈 Metrics server listening on port ${metricsPort}`);
+});
+
 const desiredPort = Number(process.env.PORT || 3000);
 const portToUse = await getPort({
     port: portNumbers(desiredPort, desiredPort + 100),
@@ -244,6 +291,9 @@ ${chalk.bold('Press Ctrl+C to stop')}
 closeWithGrace(async () => {
     await new Promise((resolve, reject) => {
         server.close((e) => (e ? reject(e) : resolve('ok')));
+    });
+    await new Promise((resolve, reject) => {
+        metricsServer.close((e) => (e ? reject(e) : resolve('ok')));
     });
 });
 

--- a/server/prometheus.server.ts
+++ b/server/prometheus.server.ts
@@ -1,0 +1,64 @@
+import * as client from 'prom-client';
+
+// Recreate the singleton function here, we don't want to import it from
+// the utils because this is used by server index.ts which can only import the JS
+// compiled directly from this file, and I don't want to move it to the server folder
+function singleton<Value>(name: string, value: () => Value): Value {
+    const g = global as any;
+    g.__singletons ??= {};
+    g.__singletons[name] ??= value();
+    return g.__singletons[name];
+}
+
+export const prometheus = singleton('prometheus-client', () => {
+    // NOTE: if you change anything in this function you'll need to restart
+    // the dev server to see your changes.
+
+    const requestCounter = new client.Counter({
+        name: 'http_request_count',
+        help: 'Number of HTTP requests',
+        labelNames: ['method', 'path', 'status'] as const,
+    });
+
+    const requestDuration = new client.Histogram({
+        name: 'http_request_duration_histogram',
+        help: 'Duration of HTTP requests',
+        labelNames: ['method', 'path', 'status'] as const,
+        buckets: [1, 10, 100, 1000, 5000, 10000, 30000],
+    });
+
+    const requestDurationSummary = new client.Summary({
+        name: 'http_request_duration_summary',
+        help: 'Duration of HTTP requests',
+        labelNames: ['method', 'path', 'status'] as const,
+    });
+
+    const sqlQueryCounter = new client.Counter({
+        name: 'sql_query_count',
+        help: 'Number of SQL queries executed',
+        labelNames: ['query'] as const,
+    });
+
+    const sqlQueryDuration = new client.Histogram({
+        name: 'sql_query_duration_histogram',
+        help: 'Duration of SQL queries executed',
+        labelNames: ['query'] as const,
+        buckets: [1, 10, 100, 1000, 5000, 10000, 30000],
+    });
+
+    const sqlQueryDurationSummary = new client.Summary({
+        name: 'sql_query_duration_summary',
+        help: 'Duration of SQL queries executed',
+        labelNames: ['query'] as const,
+    });
+
+    return {
+        client,
+        requestCounter,
+        requestDuration,
+        requestDurationSummary,
+        sqlQueryCounter,
+        sqlQueryDuration,
+        sqlQueryDurationSummary,
+    };
+});


### PR DESCRIPTION
Add prometheus metrics and configure fly to consume them. Allows for custom metrics

Included metrics:
- Request count
  - labels: method, path, status
- Request duration (histogram + summary)
  - labels: method, path, status
- SQL query count
  - labels: query
- SQL query duration
  - labels: query

A label allows grouping in Grafana. E.g. show the average request duration by path, or show the SQL queries which take the longest to execute.